### PR TITLE
fix: corrigindo a documentacao do mkdocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ dist-ssr
 site
 
 # Python venv
-venv
+.venv
 
 # Vite build da landing
 /docs/land/dist/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,28 +50,26 @@ theme:
       accent: "#1A4568" 
 
 plugins:
-        - glightbox:
-                  touchNavigation: true
-                  loop: false
-                  effect: zoom
-                  slide_effect: slide
-                  width: 100%
-                  height: auto
-                  zoomable: true
-                  draggable: true
-                  skip_classes:
-                          - custom-skip-class-name
-                  auto_caption: false
-                  caption_position: bottom
-                  
+  - glightbox:
+      touchNavigation: true
+      loop: false
+      effect: zoom
+      slide_effect: slide
+      width: 100%
+      height: auto
+      zoomable: true
+      draggable: true
+      skip_classes:
+        - custom-skip-class-name
+      auto_caption: false
+      caption_position: bottom
+  - exclude:
+      glob:
+        - "land/node_modules/**"
+
 extra_css:
   - assets/stylesheets/extra.css
   - land/dist/assets/index-D5Lwlgl_.css
 
 extra_javascript:
   - land/dist/assets/index-BMjkV8U-.js
-
-plugins:
-  - exclude:
-      glob:
-        - "land/node_modules/**"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mkdocs>=1.5.3
 mkdocs-material>=9.1.9
 mkdocs-material-extensions>=1.1.1
 mkdocs-exclude>=1.0.1
+mkdocs-glightbox>=0.4.0


### PR DESCRIPTION
# 🚀 Descrição

- Foram adicionados em requirements.txt as bibliotecas para rodar a documentacao;
- O gitignore sofreu um ajuste no venv para ignorar, de fato, o arquivo gerado na máquina.
- O arquivo mkdocs foi refatorado para juntar os dois topicos de plugins.

---

# 📋 Tipo de mudança

<!-- Marque com "x" as opções que se aplicam -->

- [X] 🐛 Bugfix (corrige um problema)
- [ ] ✨ Nova funcionalidade
- [X] ♻️ Refatoração de código (nenhuma funcionalidade alterada)
- [ ] 📚 Atualização de documentação
- [ ] 🔧 Configuração ou infraestrutura
- [ ] 🧪 Testes adicionados ou atualizados
- [ ] Outro: _______

---

# ✅ Checklist

<!-- Garanta que todas as etapas abaixo foram seguidas -->

- [X] O código segue o padrão de estilo do projeto
- [X] Foi testado localmente
- [X] Todos os testes existentes passaram
- [X] Foram adicionados testes relacionados, se necessário
- [X] A documentação foi atualizada (se necessário)
- [X] A branch está atualizada com a `main` ou `dev`

---

# 🧪 Como testar

<!-- Instruções para reproduzir/testar a mudança localmente -->

1. Crie o venv para instalar as dependências do mkdocs
```bash
python3 -m venv .venv
```

2. Ative o arquivo venv gerado
```bash
source .venv/bin/activate
```

3. Execute o pip install de requirements.txt
```bash
pip install -r requirements.txt
```

4. Rode localmente o mkdocs na sua máquina
```bash
mkdocs serve
```

---
